### PR TITLE
allow to pass any function script and runtime

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -8,7 +8,6 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| archive | n/a |
 | aws | n/a |
 
 ## Inputs

--- a/USAGE.md
+++ b/USAGE.md
@@ -21,9 +21,11 @@ No requirements.
 | function\_name | Name of the aws lambda function | `string` | n/a | yes |
 | handler | Handler for the aws lambda function, the structure should be the following --> filename.mainfunction | `string` | n/a | yes |
 | lambda\_role\_name | Name of the aws lambda execution role | `string` | n/a | yes |
+| lambda\_runtime | Lambda runtime i.e <python3.8> | `string` | `"python3.8"` | no |
 | output\_path | The path and name of the resulting zip file | `string` | n/a | yes |
 | region | n/a | `string` | `"us-east-1"` | no |
 | schedule\_expression | Cloudwatch rule rate expression for how frequent you want the lambda function to run | `string` | n/a | yes |
+| source\_code\_hash | hash of the current zip file, changes in the function code will produce an update of the lambda function | `string` | n/a | yes |
 | source\_file | The path in your filesystem where your script is located | `string` | n/a | yes |
 | table\_name | Name of the DynamoDB table | `string` | n/a | yes |
 

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,0 @@
-data "aws_caller_identity" "current" {}
-
-data "archive_file" "lambda_zip" {
-  type        = "zip"
-  source_file = var.source_file
-  output_path = var.output_path
-}

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,10 @@ locals {
 resource "aws_lambda_function" "check_sgs" {
   filename         = var.output_path
   function_name    = var.function_name
-  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  source_code_hash = var.source_code_hash
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = var.handler
-  runtime          = "python3.8"
+  runtime          = var.lambda_runtime
   timeout          = 10
 
   environment {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,17 @@ variable "function_name" {
   description = "Name of the aws lambda function"
 }
 
+variable "lambda_runtime" {
+  type = string
+  description = "Lambda runtime i.e <python3.8>"
+  default = "python3.8"
+}
+
+variable "source_code_hash" {
+  type = string
+  description = "hash of the current zip file, changes in the function code will produce an update of the lambda function"
+}
+
 variable "table_name" {
   type        = string
   description = "Name of the DynamoDB table"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

This PR suggests a fundamental change in the module in which the values of the script itself and the runtime itself are parameterized instead of enforced by the module.

The original python script will remain as a simple use case of how to glue together programatically the lambda function along with the dynamoDB table, but of course, since the script and runtime are not enforced anymore, the intention between this two main resources is now arbitrary a depends on the user invoking and using this module.

### Affected core subsystem(s)
<!-- Please provide affected core subsystem(s). -->

### Description of change
<!-- Please provide a description of the change here. -->
